### PR TITLE
Fix the global binary name

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "name": "Jerry Fan"
   },
   "bin": {
-    "license-checker": "./bin/concat-licenses"
+    "concat-licenses": "./bin/concat-licenses"
   },
   "bugs": {
     "url": "http://github.com/TheGuardianWolf/concat-licenses/issues"


### PR DESCRIPTION
The name of the binary created via npm -g is wrong and means that the example usage gives an error.