### PR TITLE
Add --warnIfMissing to warn if a package has no license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ concat-licenses --out=./LICENSE.lib.txt
 * --development only show development dependencies.
 * --unknown report guessed licenses as unknown licenses.
 * --onlyunknown only list packages with unknown or guessed licenses.
+* --warnIfMissing warns if a package does not provide a license file.
 * --search [filepath] look in the following npm project directory.
 * --out [filepath] write the data to a specific file.
 * --exclude [list] exclude modules which licenses are in the comma-separated list from the output.

--- a/bin/concat-licenses
+++ b/bin/concat-licenses
@@ -25,6 +25,7 @@ if (args.help) {
         '   --development only show development dependencies.',
         '   --unknown report guessed licenses as unknown licenses.',
         '   --onlyunknown only list packages with unknown or guessed licenses.',
+        '   --warnIfMissing warns if a package does not provide a license file.',
         '   --search [filepath] look in the following npm project directory.',
         '   --out [filepath] write the data to a specific file.',
         '   --exclude [list] exclude modules which licenses are in the comma-separated list from the output',

--- a/lib/args.js
+++ b/lib/args.js
@@ -16,6 +16,7 @@ var nopt = require('nopt'),
         out: path,
         unknown: Boolean,
         onlyunknown: Boolean,
+        warnIfMissing: Boolean,
         includeCurrent: Boolean,
         exclude: String,
         title: String

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const chalk = require('chalk');
 const checker = require('license-checker');
 const path = require('path');
 
@@ -25,6 +26,8 @@ module.exports.concat = (options, callback) => {
                     outputString += `${key}\n`;
                     outputString += `${licenseType}\n`;
                     outputString += `${String(fs.readFileSync(licensePath))}\n\n`;
+                } else if (options.warnIfMissing) {
+                    console.warn(chalk.yellow.bold(`WARNING: ${key} does not provide a license file.`));
                 }
             });
         } else {


### PR DESCRIPTION
If --warnIfMissing is specified, then a warning will be emitted if a
package does not provide a license file.